### PR TITLE
faceboxesのbatch処理を追加

### DIFF
--- a/faceboxes_pytorch/faceboxes_face_detector.py
+++ b/faceboxes_pytorch/faceboxes_face_detector.py
@@ -4,7 +4,8 @@ import numpy as np
 from .data import cfg
 from .layers.functions.prior_box import PriorBox
 from .models.faceboxes import FaceBoxes
-from .utils.box_utils import decode
+from .utils.box_utils import decode, batch_decode, get_faceboxes_max_batch_size
+from typing import List, Tuple
 
 class FaceBoxesFaceDetector(object):
     def __init__(self, use_gpu=False):
@@ -90,3 +91,82 @@ class FaceBoxesFaceDetector(object):
         scores, boxes = zip(*scores_and_boxes)
 
         return scores, boxes
+
+
+    def get_batch_faceboxes(self, image_list:List[np.ndarray], *, batch_size=-1, threshold=0.2)->List[Tuple[List[float],List[np.ndarray]]]:
+        """
+        image_list: List[np.ndarray] 同じサイズの画像のリスト
+        batch_size: image_listの中から何個処理するかを指定する. デフォルトの場合はgpuの空きメモリから算出する
+        threshold: faceboxesのconfの閾値
+
+        return: List[Tuple[confのリスト],[BoundingBoxのリスト]]
+        """
+
+        if len(image_list) == 0:
+            return [([],[])]
+
+        im_height, im_width, im_ch = image_list[0].shape
+
+        if batch_size == -1:
+            # batch_sizeが未指定の場合はgpuの空きメモリと画像1枚あたりの容量から許容枚数を算出し、安全マージンの7掛けした値をbatch_sizeとして使用する
+            torch.cuda.empty_cache()
+            batch_size = get_faceboxes_max_batch_size(width=im_width, height=im_height, ch=im_ch)
+            batch_size = int(batch_size * 0.7)
+
+        resize = 1
+
+        results = []
+
+        priorbox = PriorBox(cfg, image_size=(im_height, im_width))
+        priors = priorbox.forward()
+        priors = priors.to(self.device)
+        prior_data = priors.data
+
+        for i in range(0, int(len(image_list) / batch_size) + 1):
+            images = image_list[batch_size * i: min(len(image_list), batch_size * (i+1))]
+
+            im_height, im_width, im_ch = images[0].shape
+            scale = torch.Tensor([im_width, im_height, im_width, im_height])
+            images = np.array(images).reshape(len(images), im_height, im_width, im_ch)
+
+            imgs = torch.from_numpy(images)
+            imgs = imgs.to(self.device)
+            scale = scale.to(self.device)
+
+            imgs = imgs.to(torch.float32)
+            imgs = torch.sub(imgs, torch.tensor((104,117,123)).to(self.device))
+            imgs = imgs.permute(0,3,1,2)
+
+            loc, conf = self.net(imgs)
+
+            boxes = batch_decode(loc.data.squeeze(0), prior_data, cfg['variance'])
+            boxes = boxes * scale / resize
+
+            boxes = boxes.cpu().numpy()
+            scores = conf.data.cpu().numpy()[:, :, 1]
+
+            thres_tuple = torch.nonzero(torch.where(conf[:,:,1] > threshold, 1, 0), as_tuple=True)
+            image_inds = thres_tuple[0].data.cpu().numpy()
+            boxes_inds = thres_tuple[1].data.cpu().numpy()
+
+            # ここgpu化しなくても処理時間が支配的ではないのでcpuでやる
+            result = []
+            for i in range(0, len(images)):
+                inds = boxes_inds[np.where(image_inds == i)]
+                if len(inds) == 0:
+                    result.append(([],[]))
+                    continue
+
+                scores_and_boxes = zip(scores[i][inds], boxes[i][inds])
+                scores_and_boxes = sorted(scores_and_boxes, key=lambda x: -x[0])
+                s, b = zip(*scores_and_boxes)
+                result.append((s,b))
+
+            results += result
+
+            # 以降gpu上の画像は使わないので解放する
+            # 速度に影響なさそうなのでループごとに実行
+            del imgs
+            torch.cuda.empty_cache()
+
+        return results

--- a/faceboxes_pytorch/faceboxes_face_detector.py
+++ b/faceboxes_pytorch/faceboxes_face_detector.py
@@ -112,11 +112,14 @@ class FaceBoxesFaceDetector(object):
 
         im_height, im_width, im_ch = image_list[0].shape
 
-        if batch_size == -1:
+        if (batch_size == -1) and (torch.cuda.is_available()):
             # batch_sizeが未指定の場合はgpuの空きメモリと画像1枚あたりの容量から許容枚数を算出し、安全マージンの7掛けした値をbatch_sizeとして使用する
             torch.cuda.empty_cache()
             batch_size = get_faceboxes_max_batch_size(width=im_width, height=im_height, ch=im_ch)
             batch_size = int(batch_size * 0.7)
+
+        if (batch_size == -1) and (not torch.cuda.is_available()):
+            batch_size = len(image_list)
 
         batch_size = min(len(image_list), batch_size)
         resize = 1

--- a/faceboxes_pytorch/faceboxes_face_detector.py
+++ b/faceboxes_pytorch/faceboxes_face_detector.py
@@ -186,6 +186,16 @@ class FaceBoxesFaceDetector(object):
     @torch.no_grad()
     def get_batch_faceboxes_with_resize(self, image_list:List[np.ndarray], *, resize_target_width=360, resize_target_height=640,
                                     batch_size=-1, threshold=0.2)->List[Tuple[List[float],List[np.ndarray]]]:
+        """
+        image_list: List[np.ndarray] 画像のリスト 内部でresizeするため、同じ大きさである必要はない
+        resize_target_width: 内部でresizeするときのwidth
+        resize_target_height: 内部でresizeするときのheight
+          上二つのデフォルト値はアスペクト比9:16にしている
+        batch_size: image_listの中から何個処理するかを指定する. デフォルトの場合はgpuの空きメモリから算出する.値は2以上にすること
+        threshold: faceboxesのconfの閾値
+
+        return: List[Tuple[confのリスト],[BoundingBoxのリスト]]
+        """
 
         resize_target_resize_size = (resize_target_width, resize_target_height)
         shapes = [i.shape for i in image_list]

--- a/faceboxes_pytorch/faceboxes_face_detector.py
+++ b/faceboxes_pytorch/faceboxes_face_detector.py
@@ -9,7 +9,6 @@ from typing import List, Tuple
 
 class FaceBoxesFaceDetector(object):
     def __init__(self, use_gpu=False):
-        torch.set_grad_enabled(False)
         # net and model
         self.net = FaceBoxes(phase='test', size=None, num_classes=2)    # initialize detector
         weight_path = os.path.normpath(os.path.join(os.path.dirname(os.path.abspath(__file__)), 'weights/FaceBoxes.pth'))
@@ -56,6 +55,7 @@ class FaceBoxesFaceDetector(object):
         model.load_state_dict(pretrained_dict, strict=False)
         return model
 
+    @torch.no_grad()
     def get_faceboxes(self, image, threshold=0.2):
         resize = 1
 
@@ -92,7 +92,7 @@ class FaceBoxesFaceDetector(object):
 
         return scores, boxes
 
-
+    @torch.no_grad()
     def get_batch_faceboxes(self, image_list:List[np.ndarray], *, batch_size=-1, threshold=0.2)->List[Tuple[List[float],List[np.ndarray]]]:
         """
         image_list: List[np.ndarray] 同じサイズの画像のリスト

--- a/faceboxes_pytorch/faceboxes_face_detector.py
+++ b/faceboxes_pytorch/faceboxes_face_detector.py
@@ -58,14 +58,16 @@ class FaceBoxesFaceDetector(object):
     def get_faceboxes(self, image, threshold=0.2):
         resize = 1
 
-        img = np.float32(image)
-        im_height, im_width, _ = img.shape
-        scale = torch.Tensor([img.shape[1], img.shape[0], img.shape[1], img.shape[0]])
-        img -= (104, 117, 123)
-        img = img.transpose(2, 0, 1)
-        img = torch.from_numpy(img).unsqueeze(0)
+        im_height, im_width, _ = image.shape
+        scale = torch.Tensor([im_width, im_height, im_width, im_height])
+
+        img = torch.from_numpy(image).unsqueeze(0)
         img = img.to(self.device)
+        img = img.to(torch.float32)
         scale = scale.to(self.device)
+
+        img = torch.sub(img, torch.tensor((104,117,123)).to(self.device))
+        img = img.permute(0,3,1,2)
 
         loc, conf = self.net(img)  # forward pass
         priorbox = PriorBox(cfg, image_size=(im_height, im_width))

--- a/faceboxes_pytorch/faceboxes_face_detector.py
+++ b/faceboxes_pytorch/faceboxes_face_detector.py
@@ -59,16 +59,14 @@ class FaceBoxesFaceDetector(object):
     def get_faceboxes(self, image, threshold=0.2):
         resize = 1
 
-        im_height, im_width, _ = image.shape
-        scale = torch.Tensor([im_width, im_height, im_width, im_height])
-
-        img = torch.from_numpy(image).unsqueeze(0)
+        img = np.float32(image)
+        im_height, im_width, _ = img.shape
+        scale = torch.Tensor([img.shape[1], img.shape[0], img.shape[1], img.shape[0]])
+        img -= (104, 117, 123)
+        img = img.transpose(2, 0, 1)
+        img = torch.from_numpy(img).unsqueeze(0)
         img = img.to(self.device)
-        img = img.to(torch.float32)
         scale = scale.to(self.device)
-
-        img = torch.sub(img, torch.tensor((104,117,123)).to(self.device))
-        img = img.permute(0,3,1,2)
 
         loc, conf = self.net(img)  # forward pass
         priorbox = PriorBox(cfg, image_size=(im_height, im_width))

--- a/faceboxes_pytorch/faceboxes_face_detector.py
+++ b/faceboxes_pytorch/faceboxes_face_detector.py
@@ -116,6 +116,7 @@ class FaceBoxesFaceDetector(object):
             batch_size = get_faceboxes_max_batch_size(width=im_width, height=im_height, ch=im_ch)
             batch_size = int(batch_size * 0.7)
 
+        batch_size = min(len(image_list), batch_size)
         resize = 1
 
         results = []
@@ -176,8 +177,6 @@ class FaceBoxesFaceDetector(object):
             results += result
 
             # 以降gpu上の画像は使わないので解放する
-            # 速度に影響なさそうなのでループごとに実行
             del imgs
-            torch.cuda.empty_cache()
 
         return results

--- a/faceboxes_pytorch/utils/box_utils.py
+++ b/faceboxes_pytorch/utils/box_utils.py
@@ -310,7 +310,6 @@ def get_faceboxes_max_batch_size(width=1080, height=1920, ch=3, print_status_flg
     gpu_batch_sizes = [int(int(info['memory.free']) / image_mega_byte) for info in gpu_info]
 
     if print_status_flg:
-        print(f'cpu_batch_size: {cpu_batch_size}')
         print(f'gpu_batch_sizes: {gpu_batch_sizes}')
 
     return  min(gpu_batch_sizes)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "faceboxes_pytorch"
-version = "0.1.2"
+version = "0.1.3"
 description = ""
 authors = ["Your Name <you@example.com>"]
 


### PR DESCRIPTION
batch処理を追加
1000枚あたりの処理時間が、
get_faceboxes(): 12.5s
get_batch_faceboxes(): 1.67s
となる（約10分の1

## 動作確認

各画像での
* boundingbox座標が0.01以上のずれがない(画像座標)
* confの値が0.0001以上のずれがない
ことを確認している

![image](https://user-images.githubusercontent.com/51253910/145329749-7a87bb6c-ece6-45b0-9461-58ef2b7c87fc.png)
